### PR TITLE
Add link friction coefficients (ODE)

### DIFF
--- a/panda/model.sdf
+++ b/panda/model.sdf
@@ -24,6 +24,14 @@
                         <uri>model://panda/meshes/collision/link0.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>1.05</mu>
+                            <mu2>1.05</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>-0.025566 -2.88e-05 0.057332 0 0 0</pose>
@@ -54,6 +62,14 @@
                         <uri>model://panda/meshes/collision/link1.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>1.05</mu>
+                            <mu2>1.05</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>0 -0.0324958 -0.0675818 0 0 0</pose>
@@ -84,6 +100,14 @@
                         <uri>model://panda/meshes/collision/link2.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>1.05</mu>
+                            <mu2>1.05</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>0 -0.06861 0.0322285 0 0 0</pose>
@@ -114,6 +138,14 @@
                         <uri>model://panda/meshes/collision/link3.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>1.05</mu>
+                            <mu2>1.05</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>0.0469893 0.0316374 -0.031704 0 0 0</pose>
@@ -144,6 +176,14 @@
                         <uri>model://panda/meshes/collision/link4.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>1.05</mu>
+                            <mu2>1.05</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>-0.0360446 0.0336853 0.031882 0 0 0</pose>
@@ -174,6 +214,14 @@
                         <uri>model://panda/meshes/collision/link5.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>1.05</mu>
+                            <mu2>1.05</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>0 0.0610427 -0.104176 0 0 0</pose>
@@ -204,6 +252,14 @@
                         <uri>model://panda/meshes/collision/link6.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>1.05</mu>
+                            <mu2>1.05</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>0.0510509 0.009108 0.0106343 0 0 0</pose>
@@ -234,6 +290,14 @@
                         <uri>model://panda/meshes/collision/link7.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>1.05</mu>
+                            <mu2>1.05</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>0.0109695 0.0107965 0.0650411 0 0 0</pose>
@@ -383,6 +447,14 @@
                         <uri>model://panda/meshes/collision/hand.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>1.05</mu>
+                            <mu2>1.05</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>0 0.0015244 0.0275912 0 0 0</pose>
@@ -413,6 +485,14 @@
                         <uri>model://panda/meshes/collision/finger.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>2.15</mu>
+                            <mu2>2.15</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>0 0.0145644 0.0227941 0 0 0</pose>
@@ -445,6 +525,14 @@
                         <uri>model://panda/meshes/collision/finger.stl</uri>
                     </mesh>
                 </geometry>
+                <surface>
+                    <friction>
+                        <ode>
+                            <mu>2.15</mu>
+                            <mu2>2.15</mu2>
+                        </ode>
+                    </friction>
+                </surface>
             </collision>
             <inertial>
                 <pose>0 0.0145644 0.0227941 0 0 3.141592653589793</pose>


### PR DESCRIPTION
- Body links considered as aluminium
   - Ref https://engineeringlibrary.org/reference/coefficient-of-friction
- Finger links considered as rubber, with guesstimated value
   - Ref https://nvlpubs.nist.gov/nistpubs/jres/28/jresv28n4p439_a1b.pdf