### PR TITLE
Use a more robust tag for docker

### DIFF
--- a/.docker/build.bash
+++ b/.docker/build.bash
@@ -3,7 +3,9 @@
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" &>/dev/null && pwd)"
 PROJECT_DIR="$(dirname "${SCRIPT_DIR}")"
 
-TAG="andrejorsula/$(basename "${PROJECT_DIR}")"
+TAG=$(git -C "${PROJECT_DIR}" remote get-url origin | sed 's/.*\///; s/\.git$//')
+TAG=${TAG}-$(git -C "${PROJECT_DIR}" branch --show-current)
+TAG=${TAG}-$(git -C "${PROJECT_DIR}" rev-parse --short HEAD)
 
 if [ "${#}" -gt "0" ]; then
     if [[ "${1}" != "-"* ]]; then

--- a/.docker/run.bash
+++ b/.docker/run.bash
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-TAG="andrejorsula/panda_ign_moveit2"
+TAG=$(git -C "${PROJECT_DIR}" remote get-url origin | sed 's/.*\///; s/\.git$//')
+TAG=${TAG}-$(git -C "${PROJECT_DIR}" branch --show-current)
+TAG=${TAG}-$(git -C "${PROJECT_DIR}" rev-parse --short HEAD)
 
 ## Forward custom volumes and environment variables
 CUSTOM_VOLUMES=()
@@ -81,7 +83,7 @@ if [ -n "${ROS_DOMAIN_ID}" ]; then
 fi
 # Synchronize IGN_PARTITION with host
 if [ -n "${IGN_PARTITION}" ]; then
-    CUSTOM_ENVS+=("IGN_PARTITION=${IGN_PARTITION}")
+    CUSTOM_ENVS+=("GZ_PARTITION=${GZ_PARTITION}")
 fi
 # Synchronize RMW configuration with host
 if [ -n "${RMW_IMPLEMENTATION}" ]; then


### PR DESCRIPTION
The docker image tags are not linked to a particular code version, that could end up in build one branch or code and using a different one. The PR builds tags using the branch and the HEAD sha.

